### PR TITLE
Make mod stop falsely registering Cryptid as being enabled

### DIFF
--- a/lovely.toml
+++ b/lovely.toml
@@ -126,7 +126,6 @@ pattern = '''function love.load()'''
 position = "before"
 payload = '''
 if not Cryptid then 
-    Cryptid = {}
     CryptLib = true
     Cryptid.aliases = {}
     Cryptid.pointerblist = {}


### PR DESCRIPTION
why does it do this

this just causes crashes with other mods that check for Cryptid

Fixes #1 